### PR TITLE
Fix backend startup crash by handling MySQL connection errors 

### DIFF
--- a/backend/connect.js
+++ b/backend/connect.js
@@ -14,7 +14,10 @@ export const db=mysql.createConnection(
 
 db.connect(
     (err)=>{
-        if(err) throw err;
+        if(err){
+            console.error("MySQL connection error:", err.message || err);
+            return;
+        }
         console.log("Connected to MySQL Server");
     }
 )


### PR DESCRIPTION
## Summary
Fix backend startup crash by removing `throw err` from `backend/connect.js` and logging MySQL connection failures gracefully.

## Changes
- Updated `backend/connect.js`
- Removed crash behavior on DB connect error
- Retained backend startup logging behavior

## Verification
- `cd backend && npm run dev`
- Backend stays up and logs DB connection errors instead of crashing

closes #38 