### PR TITLE
fix(tasks): validate userIds in assignTask and add comment input validation

### DIFF
--- a/backend_mern/controllers/taskController.js
+++ b/backend_mern/controllers/taskController.js
@@ -312,8 +312,25 @@ export const assignTask = asyncHandler(async (req, res) => {
     throw new Error("userIds must be an array");
   }
 
+  // Verify every provided id is a valid ObjectId
+  const invalidIds = userIds.filter((uid) => !validateObjectId(uid));
+  if (invalidIds.length > 0) {
+    res.status(400);
+    throw new Error(`Invalid user id(s): ${invalidIds.join(", ")}`);
+  }
+
+  // Verify every provided user actually exists before assigning
+  const existingCount = await User.countDocuments({ _id: { $in: userIds } });
+  if (existingCount !== userIds.length) {
+    res.status(400);
+    throw new Error("One or more assigned users do not exist");
+  }
+
   const task = await Task.findById(id);
-  if (!task) throw new Error("Task not found");
+  if (!task) {
+    res.status(404);
+    throw new Error("Task not found");
+  }
 
   task.assignedTo = userIds;
 

--- a/backend_mern/routes/taskRoutes.js
+++ b/backend_mern/routes/taskRoutes.js
@@ -1,4 +1,4 @@
-import express from "express";
+﻿import express from "express";
 import protect from "../middlewares/authWebToken.js";
 import admin from "../middlewares/adminMiddleware.js";
 import { validate } from "../middlewares/validate.js";
@@ -20,6 +20,7 @@ import {
   createTaskSchema,
   updateTaskSchema,
   assignTaskSchema,
+  addCommentSchema,
 } from "../validations/taskValidation.js";
 
 const router = express.Router();
@@ -45,7 +46,7 @@ router.put("/:id", protect, validate(updateTaskSchema), updateTask);
 router.delete("/:id", protect, deleteTask);
 
 // 🔥 Add Comment
-router.post("/:id/comment", protect, addComment);
+router.post("/:id/comment", protect, validate(addCommentSchema), addComment);
 
 // 🔥 Toggle Watcher (subscribe/unsubscribe)
 router.patch("/:id/watch", protect, toggleWatcher);

--- a/backend_mern/validations/taskValidation.js
+++ b/backend_mern/validations/taskValidation.js
@@ -1,4 +1,4 @@
-import { z } from "zod";
+﻿import { z } from "zod";
 
 export const createTaskSchema = z.object({
   title: z.string().min(1, "Title is required"),
@@ -24,5 +24,14 @@ export const updateTaskSchema = z.object({
 });
 
 export const assignTaskSchema = z.object({
-  userId: z.string().min(1, "userId is required"),
+  userIds: z
+    .array(z.string().min(1, "Each userId must be a non-empty string"))
+    .min(1, "userIds must contain at least one user"),
+});
+
+export const addCommentSchema = z.object({
+  text: z
+    .string()
+    .min(1, "Comment text is required")
+    .max(500, "Comment must be 500 characters or fewer"),
 });


### PR DESCRIPTION
## Summary

Closes #50

Two validation gaps in the task API:

1. **`assignTaskSchema` validated the wrong field.** The schema required `userId` (a single string), but the `assignTask` controller reads `userIds` (an array). A correct `userIds` payload was rejected by the schema, while the field the controller actually consumes was never validated.

2. **`addComment` had no validation and crashed on missing text.** The `POST /:id/comment` route had no `validate()` middleware, and the controller calls `text.match(/@(\w+)/g)` directly. When `text` was missing or null, `.match()` threw `TypeError: Cannot read properties of undefined`, surfacing as an unhandled 500 instead of a clean 400.

## Changes Made

**`backend_mern/validations/taskValidation.js`**
- Rewrote `assignTaskSchema` to validate `userIds` as a non-empty array of non-empty strings, matching what the controller consumes.
- Added `addCommentSchema` validating `text` as a required string between 1 and 500 characters (mirrors the `maxlength: 500` on the Task comment subdocument).

**`backend_mern/controllers/taskController.js`**
- In `assignTask`, after the existing `Array.isArray` guard, added: (a) an ObjectId-format check for each provided id, and (b) a server-side existence check (`User.countDocuments({ _id: { $in: userIds } })`) so a task is only reassigned when every provided user actually exists.
- Made the "Task not found" branch in `assignTask` set `res.status(404)` explicitly, consistent with the other handlers in the file.
- Reused the existing `validateObjectId` helper and the already-imported `User` model — no new imports.

**`backend_mern/routes/taskRoutes.js`**
- Imported `addCommentSchema` and added `validate(addCommentSchema)` to the `POST /:id/comment` route, so missing/empty/oversized comment text now returns a 400 before reaching the controller.

## Testing

- `node --check` passes on all three changed files.
- Verified the updated zod schemas behave correctly with `safeParse`:
  - `assignTaskSchema`: accepts `{ userIds: ["<id1>", "<id2>"] }`; rejects an empty array, a non-array, and the old single-`userId` shape.
  - `addCommentSchema`: accepts valid text; rejects missing `text` (the previous 500-crash case), empty string, and text over 500 characters — all now returning a 400 via the existing `validate` middleware.
- Confirmed `assignTask` rejects malformed ObjectIds and non-existent users with a 400, and only assigns when all provided users exist.
- Confirmed `validateObjectId` (defined in the controller) and `User` (imported in the controller) are already present, so no new imports were needed.

### Notes / out of scope

The `addComment` mention-detection queries `User.find({ username: ... })`, but the User model has no `username` field — so mentions silently match nothing. That is a separate pre-existing issue and is intentionally left untouched here to keep this PR focused on the validation gaps in #50.