### PR TITLE
feat(profile): add profile picture support with Cloudinary upload and initials fallback (#58)

### DIFF
--- a/backend_mern/controllers/authController.js
+++ b/backend_mern/controllers/authController.js
@@ -2,6 +2,21 @@ import asyncHandler from "express-async-handler";
 import User from "../models/User.js";
 import generateToken from "../utils/generateToken.js";
 
+// Accepts only an https URL served from Cloudinary's media host, so the stored
+// profilePicture field can never be set to arbitrary text or a non-image origin.
+const isValidCloudinaryUrl = (value) => {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      url.hostname === "res.cloudinary.com" &&
+      url.pathname.includes("/image/upload/")
+    );
+  } catch {
+    return false;
+  }
+};
+
 // ================= REGISTER =================
 export const registerUser = asyncHandler(async (req, res) => {
   const { name, email, password } = req.body;
@@ -27,6 +42,7 @@ export const registerUser = asyncHandler(async (req, res) => {
       name: user.name,
       email: user.email,
       role: user.role,
+      profilePicture: user.profilePicture,
       token: generateToken(user._id),
     },
   });
@@ -57,6 +73,7 @@ export const loginUser = asyncHandler(async (req, res) => {
         name: user.name,
         email: user.email,
         role: user.role,
+        profilePicture: user.profilePicture,
         token: generateToken(user._id),
       },
     });
@@ -71,6 +88,49 @@ export const userProfile = asyncHandler(async (req, res) => {
   res.json({
     success: true,
     data: req.user,
+  });
+});
+
+// ================= UPDATE PROFILE PICTURE =================
+// The image is uploaded directly from the client to Cloudinary via an unsigned
+// upload preset; only the resulting secure_url reaches this endpoint, so no
+// large file payloads or storage credentials pass through the server. Sending
+// an empty string clears the picture (the UI falls back to an initials avatar).
+export const updateProfilePicture = asyncHandler(async (req, res) => {
+  const { profilePicture } = req.body;
+
+  if (typeof profilePicture !== "string") {
+    res.status(400);
+    throw new Error("profilePicture must be a string");
+  }
+
+  const trimmed = profilePicture.trim();
+
+  if (trimmed !== "" && !isValidCloudinaryUrl(trimmed)) {
+    res.status(400);
+    throw new Error("Invalid image URL");
+  }
+
+  const updated = await User.findByIdAndUpdate(
+    req.user._id,
+    { profilePicture: trimmed },
+    { new: true, runValidators: true }
+  ).select("-password");
+
+  if (!updated) {
+    res.status(404);
+    throw new Error("User not found");
+  }
+
+  res.json({
+    success: true,
+    data: {
+      _id: updated._id,
+      name: updated.name,
+      email: updated.email,
+      role: updated.role,
+      profilePicture: updated.profilePicture,
+    },
   });
 });
 

--- a/backend_mern/controllers/taskController.js
+++ b/backend_mern/controllers/taskController.js
@@ -142,7 +142,7 @@ export const getMyTasks = asyncHandler(async (req, res) => {
   const tasks = await Task.find({
     assignedTo: { $in: [req.user._id] }, // 🔥 fix
   })
-    .populate("createdBy", "name email")
+    .populate("createdBy", "name email profilePicture")
     .sort({ createdAt: -1 });
 
   res.json({
@@ -189,8 +189,8 @@ export const getAllTasks = asyncHandler(async (req, res) => {
 
   const [tasks, total] = await Promise.all([
     Task.find(filter)
-      .populate("assignedTo", "name email")
-      .populate("createdBy", "name email")
+      .populate("assignedTo", "name email profilePicture")
+      .populate("createdBy", "name email profilePicture")
       .sort({ createdAt: -1 })
       .skip(skip)
       .limit(limit),
@@ -218,9 +218,9 @@ export const getTask = asyncHandler(async (req, res) => {
   }
 
   const task = await Task.findById(id)
-    .populate("createdBy", "name email")
-    .populate("assignedTo", "name email")
-    .populate("activityLogs.user", "name email");
+    .populate("createdBy", "name email profilePicture")
+    .populate("assignedTo", "name email profilePicture")
+    .populate("activityLogs.user", "name email profilePicture");
 
   if (!task) {
     res.status(404);

--- a/backend_mern/models/User.js
+++ b/backend_mern/models/User.js
@@ -29,6 +29,10 @@ const userSchema = new mongoose.Schema(
       enum: ["active", "inactive"],
       default: "active",
     },
+    profilePicture: {
+      type: String,
+      default: "",
+    },
   },
   { timestamps: true }
 );

--- a/backend_mern/routes/authRoute.js
+++ b/backend_mern/routes/authRoute.js
@@ -4,6 +4,7 @@ import {
   loginUser,
   logoutUser,
   userProfile,
+  updateProfilePicture,
   getAllUsers,
   deleteUser,
 } from "../controllers/authController.js";
@@ -20,6 +21,7 @@ router.post("/logout", protect, logoutUser);
 
 // 👤 User
 router.get("/profile", protect, userProfile);
+router.patch("/profile/picture", protect, updateProfilePicture);
 
 // 👑 Admin only
 router.get("/users", protect, admin, getAllUsers);

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,8 @@
+VITE_API_URL=http://localhost:8000/api
+
+# Cloudinary - direct unsigned upload for user profile pictures.
+# Both values are public-safe (no API secret). In your Cloudinary dashboard,
+# create an UNSIGNED upload preset under Settings -> Upload -> Upload presets,
+# then set the cloud name and preset name below.
+VITE_CLOUDINARY_CLOUD_NAME=your_cloud_name
+VITE_CLOUDINARY_UPLOAD_PRESET=your_unsigned_preset

--- a/frontend/src/components/Avatar.jsx
+++ b/frontend/src/components/Avatar.jsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+
+// Deterministic palette so each user keeps a stable colour for their initials
+// fallback (no flicker between renders).
+const COLORS = [
+  "#4f46e5",
+  "#0ea5e9",
+  "#059669",
+  "#d97706",
+  "#dc2626",
+  "#7c3aed",
+  "#db2777",
+  "#0891b2",
+];
+
+const getInitials = (name = "") => {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+};
+
+const getColor = (name = "") => {
+  let hash = 0;
+  for (let i = 0; i < name.length; i += 1) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return COLORS[Math.abs(hash) % COLORS.length];
+};
+
+// Renders the user's profile picture when a URL is supplied, otherwise an
+// initials avatar. Falls back to initials if the image fails to load.
+export default function Avatar({ src, name = "", size = 40, className = "" }) {
+  const [errored, setErrored] = useState(false);
+  const dimension = { width: size, height: size };
+
+  if (src && !errored) {
+    return (
+      <img
+        src={src}
+        alt={name || "User avatar"}
+        onError={() => setErrored(true)}
+        style={dimension}
+        className={`rounded-full object-cover ${className}`}
+      />
+    );
+  }
+
+  return (
+    <span
+      aria-label={name || "User avatar"}
+      title={name}
+      style={{
+        ...dimension,
+        backgroundColor: getColor(name),
+        fontSize: Math.max(10, Math.round(size * 0.4)),
+      }}
+      className={`inline-flex items-center justify-center rounded-full font-semibold text-white select-none ${className}`}
+    >
+      {getInitials(name)}
+    </span>
+  );
+}

--- a/frontend/src/components/Comments.jsx
+++ b/frontend/src/components/Comments.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
 import { socket } from "../socket";
+import Avatar from "./Avatar";
 
 const Comments = ({ taskId, users = [] }) => {
   const [comments, setComments] = useState([]);
@@ -109,9 +110,16 @@ const Comments = ({ taskId, users = [] }) => {
 
         {comments.map((c) => (
           <div key={c._id} className="bg-gray-800 p-2 rounded">
-            <p className="text-sm font-semibold text-gray-200">
-              {c.user?.name || "User"}
-            </p>
+            <div className="flex items-center gap-2 mb-1">
+              <Avatar
+                src={c.user?.profilePicture}
+                name={c.user?.name || "User"}
+                size={22}
+              />
+              <p className="text-sm font-semibold text-gray-200">
+                {c.user?.name || "User"}
+              </p>
+            </div>
 
             <p className="text-sm text-gray-300">
               {c.text.split(" ").map((word, i) =>

--- a/frontend/src/components/TaskCard.jsx
+++ b/frontend/src/components/TaskCard.jsx
@@ -6,6 +6,7 @@ import TaskDetailModal from "./TaskCardDetails";
 import StatusDropdown from "./StatusDropdown";
 import AssignTaskModal from "./AssignTaskModal";
 import ConfirmDeleteModal from "./ConfirmDeleteModal";
+import Avatar from "./Avatar";
 
 export default function TaskCard({ task }) {
   const dispatch = useDispatch();
@@ -25,9 +26,9 @@ export default function TaskCard({ task }) {
       : "bg-gray-700 text-gray-300";
 
   // 🔥 MULTI USER SUPPORT
-  const assignedNames = Array.isArray(task.assignedTo)
-    ? task.assignedTo.map((u) => u.name).join(", ")
-    : "You";
+  const assignees = Array.isArray(task.assignedTo) ? task.assignedTo : [];
+  const assignedNames =
+    assignees.length > 0 ? assignees.map((u) => u.name).join(", ") : "You";
 
   const handleDelete = () => {
     dispatch(deleteTask(task._id));
@@ -53,12 +54,25 @@ export default function TaskCard({ task }) {
         <p className="text-gray-400 text-sm mt-1">{task.description}</p>
 
         {/* ASSIGNED USERS */}
-        <p className="text-xs text-gray-400 mt-2">
-          Assigned to:{" "}
-          <span className="text-gray-200 font-medium">
-            {assignedNames}
-          </span>
-        </p>
+        <div className="flex items-center gap-2 mt-2">
+          {assignees.length > 0 && (
+            <div className="flex -space-x-2">
+              {assignees.slice(0, 4).map((u) => (
+                <Avatar
+                  key={u._id}
+                  src={u.profilePicture}
+                  name={u.name}
+                  size={24}
+                  className="ring-2 ring-gray-900"
+                />
+              ))}
+            </div>
+          )}
+          <p className="text-xs text-gray-400">
+            Assigned to:{" "}
+            <span className="text-gray-200 font-medium">{assignedNames}</span>
+          </p>
+        </div>
 
         {/* FOOTER */}
         <div className="flex justify-between items-center mt-4">

--- a/frontend/src/components/TaskCardDetails.jsx
+++ b/frontend/src/components/TaskCardDetails.jsx
@@ -1,5 +1,6 @@
 ﻿import { useEffect, useState } from "react";
 import Comments from "./Comments";
+import Avatar from "./Avatar";
 import { getTaskByIdAPI } from "../features/tasks/taskService";
 
 const actionLabels = {
@@ -108,8 +109,13 @@ export default function TaskDetailModal({ taskId, initialTask, onClose, users })
                   task.assignedTo.map((user) => (
                     <span
                       key={user._id}
-                      className="bg-gray-900 text-gray-200 px-3 py-1 rounded-full text-xs"
+                      className="flex items-center gap-2 bg-gray-900 text-gray-200 px-3 py-1 rounded-full text-xs"
                     >
+                      <Avatar
+                        src={user.profilePicture}
+                        name={user.name}
+                        size={20}
+                      />
                       {user.name}
                     </span>
                   ))
@@ -139,7 +145,14 @@ export default function TaskDetailModal({ taskId, initialTask, onClose, users })
               <div className="text-sm text-gray-300 space-y-2">
                 <p>
                   <span className="text-gray-400">Created by:</span>{" "}
-                  {task?.createdBy?.name || "Unknown"}
+                  <span className="inline-flex items-center gap-2 align-middle">
+                    <Avatar
+                      src={task?.createdBy?.profilePicture}
+                      name={task?.createdBy?.name}
+                      size={20}
+                    />
+                    {task?.createdBy?.name || "Unknown"}
+                  </span>
                 </p>
                 <p>
                   <span className="text-gray-400">Created at:</span>{" "}

--- a/frontend/src/features/auth/authService.js
+++ b/frontend/src/features/auth/authService.js
@@ -8,3 +8,8 @@ export const registerAPI = async (data) => {
   const res = await api.post("/user/register", data);
   return res.data.data;
 };
+
+export const updateProfilePictureAPI = async (profilePicture) => {
+  const res = await api.patch("/user/profile/picture", { profilePicture });
+  return res.data.data;
+};

--- a/frontend/src/features/auth/authSlice.js
+++ b/frontend/src/features/auth/authSlice.js
@@ -48,6 +48,12 @@ const authSlice = createSlice({
       state.isSuccess = false;
       state.message = "";
     },
+    setProfilePicture: (state, action) => {
+      if (state.user) {
+        state.user = { ...state.user, profilePicture: action.payload };
+        localStorage.setItem("user", JSON.stringify(state.user));
+      }
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -98,5 +104,5 @@ const authSlice = createSlice({
   },
 });
 
-export const { logout, resetAuthState } = authSlice.actions;
+export const { logout, resetAuthState, setProfilePicture } = authSlice.actions;
 export default authSlice.reducer;

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -4,8 +4,12 @@ import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 
 import api from "../api/axios";
-import { logout } from "../features/auth/authSlice";
+import { logout, setProfilePicture } from "../features/auth/authSlice";
 import { getAllTasks } from "../features/tasks/taskSlice";
+import { updateProfilePictureAPI } from "../features/auth/authService";
+import { uploadToCloudinary } from "../utils/cloudinary";
+
+import Avatar from "../components/Avatar";
 
 import TaskCard from "../components/TaskCard";
 import KanbanBoard from "./KanbanBoard";
@@ -23,6 +27,7 @@ export default function AdminDashboard() {
   const { user } = useSelector((s) => s.auth);
 
   const [view, setView] = useState("list"); // list | kanban
+  const [uploading, setUploading] = useState(false);
 
   // ✅ SAFE INITIAL STATS (VERY IMPORTANT)
   const [stats, setStats] = useState({
@@ -67,6 +72,38 @@ export default function AdminDashboard() {
     navigate("/");
   };
 
+  /* ================= PROFILE PICTURE ================= */
+  const handleProfileUpload = async (e) => {
+    const file = e.target.files[0];
+    e.target.value = ""; // allow re-selecting the same file
+    if (!file) return;
+
+    try {
+      setUploading(true);
+      const url = await uploadToCloudinary(file);
+      await updateProfilePictureAPI(url);
+      dispatch(setProfilePicture(url));
+      toast.success("Profile picture updated");
+    } catch (err) {
+      toast.error(err.message || "Failed to update picture");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleRemovePhoto = async () => {
+    try {
+      setUploading(true);
+      await updateProfilePictureAPI("");
+      dispatch(setProfilePicture(""));
+      toast.success("Profile picture removed");
+    } catch (err) {
+      toast.error(err.message || "Failed to remove picture");
+    } finally {
+      setUploading(false);
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="min-h-screen bg-gray-950 text-gray-400 flex items-center justify-center">
@@ -99,11 +136,44 @@ export default function AdminDashboard() {
 
           {/* ========== ADMIN PROFILE CARD ========== */}
           <div className="bg-gray-900 border border-gray-800 rounded-xl p-6 text-center">
-            <img
-              src={`https://ui-avatars.com/api/?name=${user?.name}&background=4f46e5&color=fff`}
-              alt="Admin Avatar"
-              className="w-28 h-28 rounded-full mx-auto mb-4 border border-gray-700"
+            <Avatar
+              src={user?.profilePicture}
+              name={user?.name}
+              size={112}
+              className="mx-auto mb-4 border border-gray-700"
             />
+
+            <div className="flex items-center justify-center gap-3 mb-3">
+              <label
+                className={`cursor-pointer text-xs text-indigo-400 hover:underline ${
+                  uploading ? "opacity-50 pointer-events-none" : ""
+                }`}
+              >
+                {uploading
+                  ? "Uploading..."
+                  : user?.profilePicture
+                  ? "Change Photo"
+                  : "Upload Photo"}
+                <input
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  onChange={handleProfileUpload}
+                  disabled={uploading}
+                  className="hidden"
+                />
+              </label>
+
+              {user?.profilePicture && (
+                <button
+                  type="button"
+                  onClick={handleRemovePhoto}
+                  disabled={uploading}
+                  className="text-xs text-red-400 hover:underline disabled:opacity-50"
+                >
+                  Remove
+                </button>
+              )}
+            </div>
 
             <h2 className="font-semibold text-lg">{user?.name}</h2>
             <p className="text-sm text-gray-400">{user?.email}</p>

--- a/frontend/src/pages/UserDashboard.jsx
+++ b/frontend/src/pages/UserDashboard.jsx
@@ -4,8 +4,12 @@ import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 
 import { getMyTasks } from "../features/tasks/taskSlice";
-import { logout } from "../features/auth/authSlice";
+import { logout, setProfilePicture } from "../features/auth/authSlice";
 import { exportMyTasksCSVAPI } from "../features/tasks/taskService";
+import { updateProfilePictureAPI } from "../features/auth/authService";
+import { uploadToCloudinary } from "../utils/cloudinary";
+
+import Avatar from "../components/Avatar";
 
 import TaskCard from "../components/TaskCard";
 import CreateTaskModal from "../components/CreateTaskModal";
@@ -26,9 +30,7 @@ export default function UserDashboard() {
   const [openTaskModal, setOpenTaskModal] = useState(false);
   const [view, setView] = useState("list"); // list | kanban
   const [isExporting, setIsExporting] = useState(false);
-  const [profileImage, setProfileImage] = useState(
-    localStorage.getItem("profileImage")
-  );
+  const [uploading, setUploading] = useState(false);
 
   const notifiedRef = useRef(new Set());
 
@@ -86,17 +88,36 @@ export default function UserDashboard() {
     }
   };
 
-  /* ================= PROFILE IMAGE ================= */
-  const handleProfileUpload = (e) => {
+  /* ================= PROFILE PICTURE ================= */
+  const handleProfileUpload = async (e) => {
     const file = e.target.files[0];
+    e.target.value = ""; // allow re-selecting the same file
     if (!file) return;
 
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      localStorage.setItem("profileImage", reader.result);
-      setProfileImage(reader.result);
-    };
-    reader.readAsDataURL(file);
+    try {
+      setUploading(true);
+      const url = await uploadToCloudinary(file);
+      await updateProfilePictureAPI(url);
+      dispatch(setProfilePicture(url));
+      toast.success("Profile picture updated");
+    } catch (err) {
+      toast.error(err.message || "Failed to update picture");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleRemovePhoto = async () => {
+    try {
+      setUploading(true);
+      await updateProfilePictureAPI("");
+      dispatch(setProfilePicture(""));
+      toast.success("Profile picture removed");
+    } catch (err) {
+      toast.error(err.message || "Failed to remove picture");
+    } finally {
+      setUploading(false);
+    }
   };
 
   /* ================= USER STATS (FRONTEND) ================= */
@@ -149,24 +170,44 @@ export default function UserDashboard() {
 
           {/* ========== USER PROFILE CARD ========== */}
           <div className="bg-gray-900 border border-gray-800 rounded-xl p-6 text-center">
-            <img
-              src={
-                profileImage ||
-                `https://ui-avatars.com/api/?name=${user?.name}`
-              }
-              alt="Profile"
-              className="w-28 h-28 rounded-full mx-auto mb-4 object-cover border border-gray-700"
+            <Avatar
+              src={user?.profilePicture}
+              name={user?.name}
+              size={112}
+              className="mx-auto mb-4 border border-gray-700"
             />
 
-            <label className="cursor-pointer text-xs text-indigo-400 hover:underline">
-              Change Photo
-              <input
-                type="file"
-                accept="image/*"
-                onChange={handleProfileUpload}
-                className="hidden"
-              />
-            </label>
+            <div className="flex items-center justify-center gap-3">
+              <label
+                className={`cursor-pointer text-xs text-indigo-400 hover:underline ${
+                  uploading ? "opacity-50 pointer-events-none" : ""
+                }`}
+              >
+                {uploading
+                  ? "Uploading..."
+                  : user?.profilePicture
+                  ? "Change Photo"
+                  : "Upload Photo"}
+                <input
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  onChange={handleProfileUpload}
+                  disabled={uploading}
+                  className="hidden"
+                />
+              </label>
+
+              {user?.profilePicture && (
+                <button
+                  type="button"
+                  onClick={handleRemovePhoto}
+                  disabled={uploading}
+                  className="text-xs text-red-400 hover:underline disabled:opacity-50"
+                >
+                  Remove
+                </button>
+              )}
+            </div>
 
             <h2 className="mt-4 font-semibold text-lg">
               {user?.name}

--- a/frontend/src/utils/cloudinary.js
+++ b/frontend/src/utils/cloudinary.js
@@ -1,0 +1,48 @@
+// Direct, unsigned browser -> Cloudinary upload. The cloud name and unsigned
+// upload preset are public-safe (no API secret involved) and are supplied via
+// Vite env vars. Because the browser uploads straight to Cloudinary, large image
+// payloads never pass through the application's serverless functions.
+const CLOUD_NAME = import.meta.env.VITE_CLOUDINARY_CLOUD_NAME;
+const UPLOAD_PRESET = import.meta.env.VITE_CLOUDINARY_UPLOAD_PRESET;
+
+export const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"];
+export const MAX_IMAGE_BYTES = 2 * 1024 * 1024; // 2 MB
+
+// Uploads a single image file and resolves to its Cloudinary secure_url.
+// Throws an Error with a user-friendly message on misconfiguration, invalid
+// input, or upload failure.
+export async function uploadToCloudinary(file) {
+  if (!CLOUD_NAME || !UPLOAD_PRESET) {
+    throw new Error(
+      "Image uploads are not configured. Set VITE_CLOUDINARY_CLOUD_NAME and VITE_CLOUDINARY_UPLOAD_PRESET."
+    );
+  }
+
+  if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+    throw new Error("Please choose a JPEG, PNG, or WebP image.");
+  }
+
+  if (file.size > MAX_IMAGE_BYTES) {
+    throw new Error("Image must be 2 MB or smaller.");
+  }
+
+  const formData = new FormData();
+  formData.append("file", file);
+  formData.append("upload_preset", UPLOAD_PRESET);
+
+  const res = await fetch(
+    `https://api.cloudinary.com/v1_1/${CLOUD_NAME}/image/upload`,
+    { method: "POST", body: formData }
+  );
+
+  if (!res.ok) {
+    throw new Error("Upload failed. Please try again.");
+  }
+
+  const data = await res.json();
+  if (!data.secure_url) {
+    throw new Error("Upload failed. Please try again.");
+  }
+
+  return data.secure_url;
+}


### PR DESCRIPTION
What I built end-to-end
I did not set up MongoDB or any backend infrastructure — the database and Atlas cluster are the maintainer's existing setup. My changes layer cleanly on top of the existing stack.
Backend — 4 files changed, zero new dependencies:

models/User.js — added profilePicture: { type: String, default: "" } to the schema
controllers/authController.js — included profilePicture in register and login responses; added updateProfilePicture handler (PATCH /api/user/profile/picture) which validates that the submitted value is either an empty string (remove) or a genuine Cloudinary https://res.cloudinary.com/*/image/upload/* URL, preventing the field from being set to arbitrary text; uses findByIdAndUpdate so it works cleanly alongside the password-excluded req.user
routes/authRoute.js — wired PATCH /profile/picture behind the existing protect middleware
controllers/taskController.js — extended all assignedTo, createdBy, and activityLogs.user populate projections from "name email" to "name email profilePicture" so avatars reach task card and task detail views

Frontend — 10 files (3 new, 7 edited), zero new npm dependencies:

src/components/Avatar.jsx (new) — reusable component: renders the Cloudinary image when a URL is set, otherwise derives initials from the name ("Bathini Saketh Suman" → BS) with a deterministic background colour stable across renders; falls back to initials if the image fails to load
src/utils/cloudinary.js (new) — uploadToCloudinary(file): validates type (JPEG/PNG/WebP only) and size (≤ 2 MB) client-side before the browser uploads directly to Cloudinary via an unsigned preset; returns the secure_url. No image bytes pass through the backend serverless functions
frontend/.env.example (new) — documents the two public-safe Vite vars (VITE_CLOUDINARY_CLOUD_NAME, VITE_CLOUDINARY_UPLOAD_PRESET)
src/features/auth/authService.js — added updateProfilePictureAPI
src/features/auth/authSlice.js — added setProfilePicture reducer: updates state.user.profilePicture and re-persists to localStorage so the avatar refreshes everywhere instantly without a page reload
src/pages/UserDashboard.jsx — replaced the existing localStorage base64 upload (which stored a data URL device-locally and never reached the database) with the real flow: Cloudinary upload → PATCH backend → setProfilePicture Redux dispatch → avatar updates everywhere. Added Remove button. Upload/change/remove all work atomically
src/pages/AdminDashboard.jsx — same Avatar + upload/remove for the admin's own profile card (admins are users too; symmetric)
src/components/TaskCard.jsx — small avatar stack next to assignee names on each task card
src/components/TaskCardDetails.jsx — avatars on the assignee chips and the "Created by" line in the task detail modal
src/components/Comments.jsx — avatar beside each comment author (shows initials when no photo is set, real photo when one is)

Verification

npm run build (Vite production build) — passes, all imports resolve, bundle generated successfully
node --check on all 4 backend files — passes
ESLint on all changed files — zero new errors vs the pre-existing baseline; TaskCard.jsx actually goes down by one error due to the assignees local variable refactor

Setup needed to activate uploads
The avatar display (initials) works immediately with no configuration. To enable actual photo uploads:

Create a free Cloudinary account at cloudinary.com
Go to Settings → Upload → Upload presets → Add preset → set to Unsigned → save
Add to frontend/.env:

VITE_CLOUDINARY_CLOUD_NAME=your_cloud_name
VITE_CLOUDINARY_UPLOAD_PRESET=your_preset_name
Both values are public-safe — no API secret is involved. The frontend uploads directly to Cloudinary; only the returned secure_url is sent to the backend.
Note on other open PRs
This touches models/User.js and authController.js in different places from #60. If #60 merges first I will rebase — it is a trivial, non-overlapping addition.

<img width="1919" height="987" alt="Screenshot 2026-06-06 153218" src="https://github.com/user-attachments/assets/6e6a39f7-d88c-4b29-a202-38a2f8902e41" />
<img width="1911" height="915" alt="Screenshot 2026-06-06 153408" src="https://github.com/user-attachments/assets/f23f955b-4a4e-46f9-975c-c3a06faa8e89" />
