### PR TITLE
feat(tasks): implement soft-delete with restore + exclude deleted tasks from all queries (Closes #64)

### DIFF
--- a/backend_mern/controllers/taskController.js
+++ b/backend_mern/controllers/taskController.js
@@ -146,6 +146,8 @@ export const createTask = asyncHandler(async (req, res) => {
 
 export const getMyTasks = asyncHandler(async (req, res) => {
   const tasks = await Task.find({
+    // Exclude soft-deleted tasks so a deleted task disappears from listings.
+    isDeleted: { $ne: true },
     // Return tasks the user is assigned to OR created, so a creator still sees
     // their task after being reassigned off the assignedTo list.
     $or: [
@@ -168,6 +170,7 @@ export const getMyTasks = asyncHandler(async (req, res) => {
 export const exportMyTasks = asyncHandler(async (req, res) => {
   const tasks = await Task.find({
     assignedTo: { $in: [req.user._id] },
+    isDeleted: { $ne: true },
   })
     .sort({ createdAt: -1 })
     .lean();
@@ -190,7 +193,7 @@ export const getAllTasks = asyncHandler(async (req, res) => {
   limit = Math.min(Number(limit) || 5, MAX_LIMIT);
   page = Number(page) || 1;
 
-  const filter = {};
+  const filter = { isDeleted: { $ne: true } };
 
   if (status && VALID_STATUS.includes(status)) filter.status = status;
   if (priority && VALID_PRIORITY.includes(priority)) filter.priority = priority;
@@ -228,7 +231,7 @@ export const getTask = asyncHandler(async (req, res) => {
     throw new Error("Invalid task id");
   }
 
-  const task = await Task.findById(id)
+  const task = await Task.findOne({ _id: id, isDeleted: { $ne: true } })
     .populate("createdBy", "name email profilePicture")
     .populate("assignedTo", "name email profilePicture")
     .populate("activityLogs.user", "name email profilePicture");
@@ -256,7 +259,7 @@ export const updateTask = asyncHandler(async (req, res) => {
     throw new Error("Invalid task id");
   }
 
-  const task = await Task.findById(id);
+  const task = await Task.findOne({ _id: id, isDeleted: { $ne: true } });
   if (!task) {
     res.status(404);
     throw new Error("Task not found");
@@ -358,7 +361,7 @@ export const deleteTask = asyncHandler(async (req, res) => {
     throw new Error("Invalid task id");
   }
 
-  const task = await Task.findById(id);
+  const task = await Task.findOne({ _id: id, isDeleted: { $ne: true } });
   if (!task) {
     res.status(404);
     throw new Error("Task not found");
@@ -366,7 +369,13 @@ export const deleteTask = asyncHandler(async (req, res) => {
 
   checkPermission(task, req.user);
 
-  await task.deleteOne();
+  // Soft delete: flag the document instead of removing it, so an accidental
+  // delete can be restored and an audit trail survives. All list/detail
+  // queries filter { isDeleted: { $ne: true } }, so a soft-deleted task
+  // disappears from the UI exactly like a hard delete would.
+  task.isDeleted = true;
+  task.deletedAt = new Date();
+  await task.save();
 
   // 🔥 emit to all users
   task.assignedTo.forEach((uid) => emitTaskDeleted(uid, task._id));
@@ -374,6 +383,37 @@ export const deleteTask = asyncHandler(async (req, res) => {
   res.json({
     success: true,
     message: "Task deleted successfully",
+  });
+});
+
+/* ================= RESTORE TASK ================= */
+
+export const restoreTask = asyncHandler(async (req, res) => {
+  const { id } = req.params;
+
+  if (!validateObjectId(id)) {
+    res.status(400);
+    throw new Error("Invalid task id");
+  }
+
+  // Look up explicitly among soft-deleted tasks (the normal queries exclude
+  // them). Sets isDeleted in the query so it can find the deleted document.
+  const task = await Task.findOne({ _id: id, isDeleted: true });
+  if (!task) {
+    res.status(404);
+    throw new Error("Deleted task not found");
+  }
+
+  checkPermission(task, req.user);
+
+  task.isDeleted = false;
+  task.deletedAt = null;
+  await task.save();
+
+  res.json({
+    success: true,
+    message: "Task restored successfully",
+    data: buildTaskResponse(task),
   });
 });
 
@@ -402,7 +442,7 @@ export const assignTask = asyncHandler(async (req, res) => {
     throw new Error("One or more assigned users do not exist");
   }
 
-  const task = await Task.findById(id);
+  const task = await Task.findOne({ _id: id, isDeleted: { $ne: true } });
   if (!task) {
     res.status(404);
     throw new Error("Task not found");
@@ -436,7 +476,7 @@ export const addComment = asyncHandler(async (req, res) => {
     throw new Error("Invalid task id");
   }
 
-  const task = await Task.findById(id);
+  const task = await Task.findOne({ _id: id, isDeleted: { $ne: true } });
   if (!task) {
     res.status(404);
     throw new Error("Task not found");
@@ -505,7 +545,7 @@ export const toggleWatcher = asyncHandler(async (req, res) => {
     throw new Error("Invalid task id");
   }
 
-  const task = await Task.findById(id);
+  const task = await Task.findOne({ _id: id, isDeleted: { $ne: true } });
   if (!task) {
     res.status(404);
     throw new Error("Task not found");
@@ -546,17 +586,20 @@ export const getTaskStats = asyncHandler(async (req, res) => {
     statusAggregation,
     priorityAggregation,
   ] = await Promise.all([
-    Task.countDocuments(),
-    Task.countDocuments({ status: "done" }),
-    Task.countDocuments({ status: { $ne: "done" } }),
+    Task.countDocuments({ isDeleted: { $ne: true } }),
+    Task.countDocuments({ status: "done", isDeleted: { $ne: true } }),
+    Task.countDocuments({ status: { $ne: "done" }, isDeleted: { $ne: true } }),
     Task.countDocuments({
       deadline: { $lt: now },
       status: { $ne: "done" },
+      isDeleted: { $ne: true },
     }),
     Task.aggregate([
+      { $match: { isDeleted: { $ne: true } } },
       { $group: { _id: "$status", count: { $sum: 1 } } },
     ]),
     Task.aggregate([
+      { $match: { isDeleted: { $ne: true } } },
       { $group: { _id: "$priority", count: { $sum: 1 } } },
     ]),
   ]);

--- a/backend_mern/models/Task.js
+++ b/backend_mern/models/Task.js
@@ -195,6 +195,11 @@ const taskSchema = new mongoose.Schema(
       type: Boolean,
       default: false,
     },
+
+    deletedAt: {
+      type: Date,
+      default: null,
+    },
   },
   { timestamps: true }
 );

--- a/backend_mern/routes/taskRoutes.js
+++ b/backend_mern/routes/taskRoutes.js
@@ -11,6 +11,7 @@ import {
   getTask,
   updateTask,
   deleteTask,
+  restoreTask,
   assignTask,
   getTaskStats,
   addComment,        //  NEW
@@ -46,8 +47,11 @@ router.get("/:id", protect, getTask);
 // Update Task
 router.put("/:id", protect, validate(updateTaskSchema), updateTask);
 
-// Delete Task
+// Delete Task (soft delete)
 router.delete("/:id", protect, deleteTask);
+
+// Restore a soft-deleted task
+router.patch("/:id/restore", protect, restoreTask);
 
 // 🔥 Add Comment
 router.post("/:id/comment", protect, validate(addCommentSchema), addComment);

--- a/backend_mern/tests/soft-delete.test.mjs
+++ b/backend_mern/tests/soft-delete.test.mjs
@@ -1,0 +1,83 @@
+/**
+ * Soft-delete regression (zero dependency, Node built-ins only).
+ *
+ *   node --test backend_mern/tests/soft-delete.test.mjs
+ *
+ * Covers the fix for "soft-delete is dead code" (#64):
+ *  - deleteTask no longer hard-deletes (no task.deleteOne()); it sets
+ *    isDeleted = true and a deletedAt timestamp instead
+ *  - every task read/list/stat query filters out soft-deleted documents
+ *    ({ isDeleted: { $ne: true } } or a $match in the aggregations)
+ *  - a restore path exists and looks up the soft-deleted document explicitly
+ *  - the schema declares deletedAt
+ *  - structural assertions tie the test to the patched source files so it
+ *    cannot pass against the un-patched code
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const read = (p) => readFileSync(new URL(p, import.meta.url), "utf8");
+
+const controller = read("../controllers/taskController.js");
+const model = read("../models/Task.js");
+const routes = read("../routes/taskRoutes.js");
+
+test("deleteTask no longer hard-deletes", () => {
+  assert.ok(
+    !/await task\.deleteOne\(\)/.test(controller),
+    "deleteTask must not call task.deleteOne() (that is the hard delete being removed)"
+  );
+});
+
+test("deleteTask soft-deletes by flagging the document", () => {
+  assert.match(
+    controller,
+    /task\.isDeleted\s*=\s*true/,
+    "deleteTask must set task.isDeleted = true"
+  );
+  assert.match(
+    controller,
+    /task\.deletedAt\s*=\s*new Date\(\)/,
+    "deleteTask must stamp deletedAt"
+  );
+});
+
+test("schema declares a deletedAt field", () => {
+  assert.match(model, /deletedAt:\s*{[\s\S]*?type:\s*Date/, "Task schema must declare deletedAt: Date");
+});
+
+test("list and stat queries exclude soft-deleted tasks", () => {
+  // Count the explicit isDeleted exclusions across the controller. getMyTasks,
+  // exportMyTasks, getAllTasks (filter), getTask, updateTask, deleteTask lookup,
+  // assignTask, addComment, toggleWatcher, plus the 4 stat counts = many.
+  const exclusions = (controller.match(/isDeleted:\s*{\s*\$ne:\s*true\s*}/g) || []).length;
+  assert.ok(
+    exclusions >= 10,
+    `expected the soft-delete filter on all read/list/stat queries, found ${exclusions}`
+  );
+});
+
+test("stat aggregations match out soft-deleted tasks", () => {
+  const matches = (controller.match(/\$match:\s*{\s*isDeleted:\s*{\s*\$ne:\s*true\s*}\s*}/g) || []).length;
+  assert.ok(matches >= 2, `expected a $match stage on both stat aggregations, found ${matches}`);
+});
+
+test("getTask and mutation handlers use findOne with the isDeleted filter", () => {
+  // The detail + mutation handlers must not be reachable for a soft-deleted task.
+  assert.ok(
+    !/Task\.findById\(id\)/.test(controller),
+    "task handlers should query findOne({ _id: id, isDeleted: { $ne: true } }) rather than findById(id)"
+  );
+});
+
+test("a restore path exists in controller and routes", () => {
+  assert.match(controller, /export const restoreTask\b/, "restoreTask controller must exist");
+  assert.match(
+    controller,
+    /Task\.findOne\(\s*{\s*_id:\s*id,\s*isDeleted:\s*true\s*}\s*\)/,
+    "restoreTask must look up the soft-deleted document explicitly (isDeleted: true)"
+  );
+  assert.match(routes, /restoreTask/, "routes must import/use restoreTask");
+  assert.match(routes, /\/:id\/restore/, "a /:id/restore route must be registered");
+});


### PR DESCRIPTION
## Summary

Closes #64.

The Task model had an `isDeleted` field declared in the schema but it was never used — `deleteTask` called `task.deleteOne()` (permanent data loss), and no query anywhere filtered on `isDeleted`. This PR makes soft-delete real across the entire codebase.

---

## What was wrong

`models/Task.js` declared:

    isDeleted: { type: Boolean, default: false }

But:
- `deleteTask` called `await task.deleteOne()` — the document was gone permanently, `isDeleted` was never set
- `grep -rn "isDeleted" controllers/` returned zero matches — not a single query respected the field
- A misclick by a creator or admin was unrecoverable

---

## Changes

### models/Task.js
- Added `deletedAt: { type: Date, default: null }` alongside `isDeleted` to timestamp the deletion for audit purposes

### controllers/taskController.js
- **deleteTask**: replaced `task.deleteOne()` with `task.isDeleted = true; task.deletedAt = new Date(); await task.save()` — the document survives, the socket emit and permission check are unchanged
- **deleteTask findById**: changed to `findOne({ _id: id, isDeleted: { $ne: true } })` so re-deleting an already-soft-deleted task returns 404 (idempotent)
- **All list queries** (getMyTasks, exportMyTasks, getAllTasks): added `isDeleted: { $ne: true }` to their find filters
- **All detail/mutation handlers** (getTask, updateTask, assignTask, addComment, toggleWatcher): changed `Task.findById(id)` to `Task.findOne({ _id: id, isDeleted: { $ne: true } })` so a soft-deleted task returns 404 everywhere, exactly like a hard delete would
- **getTaskStats**: added `isDeleted: { $ne: true }` to all four `countDocuments` calls and a `$match` stage to both aggregation pipelines so stats don't count deleted tasks
- **restoreTask** (new): `PATCH /tasks/:id/restore` — queries `{ _id: id, isDeleted: true }` (finds the soft-deleted document explicitly), flips `isDeleted = false` and clears `deletedAt`, saves. This is what makes soft-delete meaningful — accidental deletes are recoverable

### routes/taskRoutes.js
- Added `PATCH /:id/restore` route (protected, no admin required — creator or assignee can restore their own task, per the existing `checkPermission` logic)

---

## Verification

Added `backend_mern/tests/soft-delete.test.mjs` — zero-dependency regression (Node built-ins only, `node --test`), 7/7 passing:

- `deleteTask no longer hard-deletes` ✅
- `deleteTask soft-deletes by flagging the document` ✅
- `schema declares a deletedAt field` ✅
- `list and stat queries exclude soft-deleted tasks` ✅
- `stat aggregations match out soft-deleted tasks` ✅
- `getTask and mutation handlers use findOne with the isDeleted filter` ✅
- `a restore path exists in controller and routes` ✅

Tests **fail 7/7 on the unpatched codebase** — every assertion is genuinely tied to the fix.

`node --check` passes on all three edited source files. All added lines are plain ASCII (pre-existing emoji and `→` arrows in the update activity log are untouched). Routes BOM preserved.

---

## Out of scope (can follow up if wanted)

A hard-delete admin route (permanent purge) — omitted to keep this PR focused. The `isDeleted: true` records are hidden from all UI but remain in the database until manually removed from MongoDB directly or via a future admin purge endpoint.