### PR TITLE
fix(admin): correct task-assign payload and make @mention usernames work

### DIFF
--- a/backend_mern/controllers/authController.js
+++ b/backend_mern/controllers/authController.js
@@ -144,11 +144,21 @@ export const logoutUser = asyncHandler(async (req, res) => {
 
 // ================= ADMIN: GET ALL USERS =================
 export const getAllUsers = asyncHandler(async (req, res) => {
-  const users = await User.find().select("-password");
+  const users = await User.find().select("-password").lean();
+
+  // The User model has no `username` field, but the @mention feature keys off
+  // one (dropdown + comment mention resolution). Derive a stable username from
+  // the email local-part so mentions work for all existing users without a DB
+  // migration. If a real `username` is ever added, it takes precedence.
+  const data = users.map((u) => ({
+    ...u,
+    username: u.username || (u.email ? u.email.split("@")[0] : ""),
+  }));
+
   res.json({
     success: true,
-    count: users.length,
-    data: users,
+    count: data.length,
+    data,
   });
 });
 

--- a/backend_mern/controllers/taskController.js
+++ b/backend_mern/controllers/taskController.js
@@ -484,12 +484,24 @@ export const addComment = asyncHandler(async (req, res) => {
 
   checkPermission(task, req.user);
 
-  // 🔥 mention detection
-  const mentionMatches = text.match(/@(\w+)/g) || [];
-  const usernames = mentionMatches.map((u) => u.replace("@", ""));
+  // 🔥 mention detection.
+  // Users have no stored `username`, so resolve @mentions against a username
+  // derived from the email local-part — the SAME derivation getAllUsers uses
+  // for the autocomplete, so what the user picks is what we match here.
+  const mentionMatches = text.match(/@([\w.-]+)/g) || [];
+  const usernames = mentionMatches.map((u) => u.slice(1).toLowerCase());
 
-  const users = await User.find({ username: { $in: usernames } });
-  const mentionedIds = users.map((u) => u._id);
+  let mentionedIds = [];
+  if (usernames.length > 0) {
+    const candidates = await User.find().select("_id email username");
+    const mentioned = candidates.filter((u) => {
+      const uname = (
+        u.username || (u.email ? u.email.split("@")[0] : "")
+      ).toLowerCase();
+      return usernames.includes(uname);
+    });
+    mentionedIds = mentioned.map((u) => u._id);
+  }
 
   const comment = {
     user: req.user._id,

--- a/frontend/src/components/AssignTaskModal.jsx
+++ b/frontend/src/components/AssignTaskModal.jsx
@@ -43,8 +43,9 @@ export default function AssignTaskModal({ task, onClose }) {
     setLoading(true);
     setError(null);
 
+    // The modal selects a single user; backend takes an array of ids.
     const res = await dispatch(
-      assignTask({ taskId: task._id, userId })
+      assignTask({ taskId: task._id, userIds: [userId] })
     );
 
     setLoading(false);

--- a/frontend/src/components/Comments.jsx
+++ b/frontend/src/components/Comments.jsx
@@ -13,10 +13,16 @@ const Comments = ({ taskId, users = [] }) => {
   // parent doesn't pass a users prop (TaskCard currently passes users={[]}).
   const [availableUsers, setAvailableUsers] = useState(users);
 
+  // Users have no stored `username`; fall back to the email local-part so the
+  // dropdown shows real handles (matches the backend mention resolver).
+  const mentionName = (u) =>
+    (u.username || (u.email ? u.email.split("@")[0] : "")).toLowerCase();
+
   // Live autocomplete list: usernames matching what's typed after "@".
-  const filteredUsers = availableUsers.filter((u) =>
-    (u.username || "").toLowerCase().startsWith(mentionQuery)
-  );
+  const filteredUsers = availableUsers.filter((u) => {
+    const name = mentionName(u);
+    return name.length > 0 && name.startsWith(mentionQuery);
+  });
 
   /* ================= FETCH COMMENTS ================= */
 
@@ -114,7 +120,7 @@ const Comments = ({ taskId, users = [] }) => {
     const words = text.split(/\s/);
     words.pop();
     const prefix = words.length ? `${words.join(" ")} ` : "";
-    setText(`${prefix}@${user.username} `);
+    setText(`${prefix}@${mentionName(user)} `);
     setShowMentions(false);
     setMentionQuery("");
   };
@@ -177,7 +183,7 @@ const Comments = ({ taskId, users = [] }) => {
                 onClick={() => handleSelectUser(user)}
                 className="p-2 hover:bg-gray-700 cursor-pointer text-white"
               >
-                @{user.username}
+                @{mentionName(user)}
               </div>
             ))}
           </div>

--- a/frontend/src/features/tasks/taskService.js
+++ b/frontend/src/features/tasks/taskService.js
@@ -37,8 +37,9 @@ export const getAllTasksAPI = async () => {
   return res.data.data;
 };
 
-export const assignTaskAPI = async ({ taskId, userId }) => {
-  const res = await api.patch(`/tasks/${taskId}/assign`, { userId });
+export const assignTaskAPI = async ({ taskId, userIds }) => {
+  // Backend expects { userIds: string[] } and assignedTo is an array field.
+  const res = await api.patch(`/tasks/${taskId}/assign`, { userIds });
   return res.data.data;
 };
 


### PR DESCRIPTION
Summary
Fixes the two bugs reported by @ankitsunil530 on PR #65.
Bug 1 — Task assignment always fails with "Assignment failed. Try again."
Traced the full request chain. The modal dispatched assignTask({ taskId, userId }) with a singular userId. The thunk destructured { taskId, userIds } — so userIds was undefined. The API helper then sent { userId } in the request body. The backend route validates with assignTaskSchema which requires userIds as a non-empty array of strings — so every assign request was rejected with a 400 before it even reached the controller. Fixed by making the whole chain consistent: the modal now dispatches userIds: [userId], the API helper destructures and sends { userIds }, and the backend receives a valid array.
Bug 2 — No list appears after typing @ in the comment box, and mentions never resolve
The entire @mention feature keys off a username field that does not exist in the User model. The model only has name, email, password, role, status, and profilePicture. As a result the dropdown rendered @undefined for every user, and the backend resolver ran User.find({ username: { $in: usernames } }) which always returned an empty array — so no mention was ever recorded and no notification was ever sent.
Fixed by deriving a stable username from the email local-part (the text before @) in all three places where the feature touches usernames, using the same derivation consistently so what the dropdown shows is exactly what the resolver matches. No database migration required — works immediately for all existing users.

Root Cause Summary
BugFileRoot causeAssignment failsAssignTaskModal.jsx + taskService.jsuserId sent instead of userIds: []@ list emptyComments.jsxu.username is always undefined — no such fieldMentions never resolvetaskController.js addCommentUser.find({ username }) always returns nothing@ source data missingauthController.js getAllUsersResponse never included a usable handle

Changes
frontend/src/features/tasks/taskService.js
Changed assignTaskAPI to destructure userIds instead of userId and send { userIds } in the request body, matching what the backend schema validates.
frontend/src/components/AssignTaskModal.jsx
Changed the dispatch from { taskId, userId } to { taskId, userIds: [userId] }. The modal is single-select but assignedTo is an array field in the Task schema so wrapping in an array is correct.
backend_mern/controllers/authController.js
getAllUsers now derives a username from the email local-part for every user before returning the list. Uses .lean() for a plain object spread. If a real username field is ever added to the model it takes precedence automatically.
backend_mern/controllers/taskController.js
addComment now resolves @mentions by fetching all users and filtering against the same email-local-part derivation that getAllUsers uses — so the handle the dropdown inserts is exactly what the resolver matches. The mention regex is also updated from \w+ to [\w.-]+ to correctly capture handles that contain dots or hyphens (common in email prefixes). The fix is guarded so the DB fetch only runs when there are actual mentions in the text.
frontend/src/components/Comments.jsx
Added a mentionName helper that derives the handle the same way as the backend. The dropdown filter, the rendered label, and the text insertion all use mentionName — so the whole mention flow is consistent end to end. Empty handles are filtered out so a bare @ never appears in the list.

Verification

node --check passes on both edited backend controllers
esbuild syntax validation passes on all three frontend files
Logic verified end to end with a simulation:

assign request body is { userIds: ["<id>"] } and passes assignTaskSchema
ankitsunil530@gmail.com derives to ankitsunil530, testmention2@gmail.com to testmention2
dropdown filter shows real handles and skips users with an empty derived handle
resolver matches the exact handle the dropdown inserts



Addresses the issues flagged by @ankitsunil530 in #65.