### PR TITLE
fix(tasks): populate comment authors and mentions in getTask (Closes #63)

### DIFF
--- a/backend_mern/controllers/taskController.js
+++ b/backend_mern/controllers/taskController.js
@@ -249,7 +249,9 @@ export const getTask = asyncHandler(async (req, res) => {
   const task = await Task.findOne({ _id: id, isDeleted: { $ne: true } })
     .populate("createdBy", "name email profilePicture")
     .populate("assignedTo", "name email profilePicture")
-    .populate("activityLogs.user", "name email profilePicture");
+    .populate("activityLogs.user", "name email profilePicture")
+    .populate("comments.user", "name email profilePicture")
+    .populate("comments.mentions", "name email profilePicture");
 
   if (!task) {
     res.status(404);


### PR DESCRIPTION
Closes #63

## Summary

Every comment in the task detail modal shows "User" as the author name
instead of the actual person who wrote it. The same issue affects mentioned
users in comments — they can't be resolved to a name either. This has been
visible since the mention-notifications work landed in #62, because that PR
wired up the notification flow but the comment list it ties into never had
its author refs resolved.

The root cause is in the getTask handler in
backend_mern/controllers/taskController.js. It populates three paths on
the Task document before returning it:

  .populate("createdBy", "name email profilePicture")
  .populate("assignedTo", "name email profilePicture")
  .populate("activityLogs.user", "name email profilePicture")

But comments.user and comments.mentions are not in that list. Both fields
are declared as ObjectId refs to the User model in commentSchema
(models/Task.js lines 22-38). Without being populated, the API returns
raw ObjectId strings for both. On the frontend, Comments.jsx renders each
author as c.user?.name || "User" — since c.user is an unpopulated ObjectId
with no .name property, every single comment falls through to "User".
Mentioned users have the same problem — the refs exist but are never
resolved, so the frontend has nothing to render.

## Note on history

This was originally submitted as PR #65. While that PR was open,
you flagged two bugs you found in local testing — the assignment modal
always failing, and the @mention dropdown showing nothing. Neither of
those was caused by #65's diff (which was purely the two populate calls).
I split them into a dedicated fix in #68, which you merged. But when #65
got closed after #68 merged, the getTask populate fix itself never actually
landed — #68 only touched addComment and the assignment chain, it did not
modify getTask at all. I pulled current main and confirmed getTask still
has the same three populate calls it always had, with no mention of
comments.user or comments.mentions. The bug is still live. This PR is a
clean resubmission of just that fix.

## Fix

Two lines added to the getTask populate chain, immediately after the
existing activityLogs.user populate, using the exact same field projection
that every other populate call in this handler uses:

  .populate("comments.user", "name email profilePicture")
  .populate("comments.mentions", "name email profilePicture")

That is the entire change. No schema changes (the refs already exist).
No frontend changes (Comments.jsx already reads c.user?.name — it just
needs the ref resolved). No changes to any other handler or route.

## What this fixes end to end

- Comment authors now show their real name instead of "User"
- Comment author profile pictures now load correctly, consistent with
  the avatar work from #61 which already receives profilePicture in
  every other populate path
- Mentioned users in comments are now accessible by name on the frontend,
  which completes the mention flow that #62 set up — the notifications
  fire correctly after #62, but the comment list rendering the mentions
  was still broken because the refs were never populated

## Verification

- node --check passes on the full controller (639 lines)
- Diff is strictly confined to the getTask populate chain — +2 populate
  calls, one semicolon moved. Every other export, function, and handler
  in the file is byte-for-byte unchanged
- Confirmed against current main before writing this: getTask has exactly
  the three populate calls listed above and nothing else. These two lines
  are genuinely missing from production