### PR TITLE
fix(tasks): persist and emit assignment notifications to newly assigned users (Closes #72)

### DIFF
--- a/backend_mern/controllers/taskController.js
+++ b/backend_mern/controllers/taskController.js
@@ -465,6 +465,11 @@ export const assignTask = asyncHandler(async (req, res) => {
     throw new Error("Task not found");
   }
 
+  // Capture newly assigned users BEFORE overwriting assignedTo, so the
+  // notification is only sent to users who weren't already assigned.
+  const previousIds = task.assignedTo.map((id) => id.toString());
+  const newlyAssigned = userIds.filter((uid) => !previousIds.includes(uid.toString()));
+
   task.assignedTo = userIds;
 
   task.activityLogs.push({
@@ -473,6 +478,28 @@ export const assignTask = asyncHandler(async (req, res) => {
   });
 
   await task.save();
+
+  // Persist a Notification per newly-assigned user (excluding the admin who
+  // is doing the assigning), then push it to their personal room so it
+  // appears in real time and survives a page reload — same pattern as
+  // addComment/mention notifications.
+  const recipientIds = newlyAssigned.filter(
+    (uid) => uid.toString() !== req.user._id.toString()
+  );
+
+  if (recipientIds.length > 0) {
+    const created = await Notification.insertMany(
+      recipientIds.map((rid) => ({
+        recipient: rid,
+        sender: req.user._id,
+        type: "assignment",
+        task: task._id,
+        message: `${req.user.name} assigned you to "${task.title}"`,
+      }))
+    );
+
+    created.forEach((doc) => emitNotification(doc.recipient, doc));
+  }
 
   userIds.forEach((uid) => emitTaskUpdate(uid, task));
 

--- a/backend_mern/tests/notifications.test.mjs
+++ b/backend_mern/tests/notifications.test.mjs
@@ -116,3 +116,82 @@ test("socket exposes an emitNotification helper", () => {
   assert.match(socket, /export const emitNotification/);
   assert.match(socket, /emit\("notification"/);
 });
+
+/* ---- Assignment notification tests (issue #72) ---- */
+
+const resolveNewlyAssigned = (userIds, previousIds, adminId) => {
+  const newlyAssigned = userIds.filter(
+    (uid) => !previousIds.includes(uid.toString())
+  );
+  return newlyAssigned.filter((uid) => uid.toString() !== adminId.toString());
+};
+
+const buildAssignmentMessage = (adminName, title) =>
+  `${adminName} assigned you to "${title}"`;
+
+test("assignment: only newly assigned users get notified, not existing assignees", () => {
+  const previous = ["u_alice"];
+  const newAssignees = ["u_alice", "u_bob", "u_carol"];
+  const admin = "u_admin";
+  const recipients = resolveNewlyAssigned(newAssignees, previous, admin);
+  // u_alice was already assigned — only u_bob and u_carol are new
+  assert.deepEqual(recipients, ["u_bob", "u_carol"]);
+});
+
+test("assignment: admin assigning themselves is excluded from recipients", () => {
+  const previous = [];
+  const newAssignees = ["u_admin", "u_bob"];
+  const admin = "u_admin";
+  const recipients = resolveNewlyAssigned(newAssignees, previous, admin);
+  assert.deepEqual(recipients, ["u_bob"]);
+  assert.ok(!recipients.includes("u_admin"));
+});
+
+test("assignment: no newly assigned users -> no notifications", () => {
+  const previous = ["u_alice", "u_bob"];
+  const newAssignees = ["u_alice", "u_bob"]; // same as before
+  const admin = "u_admin";
+  const recipients = resolveNewlyAssigned(newAssignees, previous, admin);
+  assert.equal(recipients.length, 0);
+});
+
+test("assignment notification message names the admin and the task", () => {
+  assert.equal(
+    buildAssignmentMessage("Saketh", "Fix login bug"),
+    'Saketh assigned you to "Fix login bug"'
+  );
+});
+
+test("assignTask persists + emits assignment notifications (structural)", () => {
+  const controller = read("../controllers/taskController.js");
+  // Must use Notification.insertMany for persistence
+  assert.match(
+    controller,
+    /Notification\.insertMany/,
+    "assignTask must persist notifications via insertMany"
+  );
+  // Must emit to each recipient's room
+  assert.match(
+    controller,
+    /emitNotification/,
+    "assignTask must emit assignment notifications"
+  );
+  // type must be "assignment"
+  assert.match(
+    controller,
+    /type:\s*["']assignment["']/,
+    "notification type must be 'assignment'"
+  );
+  // Must exclude the assigning admin from recipients
+  assert.match(
+    controller,
+    /req\.user\._id\.toString\(\)/,
+    "assignTask must exclude the admin from notification recipients"
+  );
+  // Must only notify newly assigned users
+  assert.match(
+    controller,
+    /newlyAssigned/,
+    "assignTask must compute newly assigned users to avoid re-notifying"
+  );
+});


### PR DESCRIPTION
## Summary

When an admin assigns a task via `PATCH /api/tasks/:id/assign`, the
controller was only emitting a live socket event (`emitTaskUpdate`) but
never creating a `Notification` document. Any user who wasn't connected
at the exact moment of assignment had no way to discover they were
assigned — the live event is gone and nothing persists.

The `Notification` model's `type` enum already includes `"assignment"`,
and the `addComment` handler already shows the correct pattern
(`Notification.insertMany` + `emitNotification`). This fix wires up the
same pattern in `assignTask` so offline users see the notification when
they next open the app, and online users see it in real time.

Closes #72

## Root cause

```js
// BEFORE — live socket only, no persistence
userIds.forEach((uid) => emitTaskUpdate(uid, task));
```

```js
// AFTER — persist first, then emit, same as addComment/mention pattern
const recipientIds = newlyAssigned.filter(
  (uid) => uid.toString() !== req.user._id.toString()
);
if (recipientIds.length > 0) {
  const created = await Notification.insertMany(
    recipientIds.map((rid) => ({
      recipient: rid,
      sender: req.user._id,
      type: "assignment",
      task: task._id,
      message: `${req.user.name} assigned you to "${task.title}"`,
    }))
  );
  created.forEach((doc) => emitNotification(doc.recipient, doc));
}
userIds.forEach((uid) => emitTaskUpdate(uid, task)); // unchanged
```

## What changed

**`backend_mern/controllers/taskController.js`**

Three additions to `assignTask`, nothing else touched:

1. Before overwriting `task.assignedTo`, capture the current assignees
   as `previousIds` and compute `newlyAssigned` — the users who weren't
   already on the task. This prevents re-notifying people who were
   already assigned when an admin updates the list.

2. Filter `newlyAssigned` to produce `recipientIds` by excluding the
   admin who is doing the assigning (same self-exclusion pattern as
   `addComment`).

3. If `recipientIds` is non-empty, call `Notification.insertMany` to
   persist one document per recipient, then call `emitNotification` for
   each so it arrives in real time. Both `Notification` and
   `emitNotification` were already imported — no new imports needed.

The existing `emitTaskUpdate` call is preserved and unchanged.

**`backend_mern/tests/notifications.test.mjs`**

Five new tests appended to the existing suite (all 8 original tests
still pass):

- Only newly assigned users notified — not existing assignees
- Admin assigning themselves is excluded from recipients
- No newly assigned users → no notifications created
- Notification message format names the admin and the task title
- Structural assertion: verifies `Notification.insertMany`, `emitNotification`,
  `type: "assignment"`, self-exclusion, and `newlyAssigned` are all
  present in the patched controller

## Verification
node backend_mern/tests/notifications.test.mjs
1..13
tests 13
pass  13
fail  0

8 original tests + 5 new assignment tests — all pass.

## Key design decisions

- **Only newly assigned users are notified.** If an admin calls assign
  again to add one more person, the existing assignees don't get a
  duplicate notification. `previousIds` is captured before
  `task.assignedTo` is overwritten.
- **Admin excluded.** If an admin assigns themselves alongside others,
  they don't receive a notification for their own action — same rule as
  `addComment`.
- **No new imports.** `Notification` (line 5) and `emitNotification`
  (line 11) were already imported at the top of `taskController.js`.
- **Mirrors `addComment` exactly.** Same `insertMany` + `emitNotification`
  pattern, same self-exclusion filter, same message format style.