### PR TITLE
fix(auth): add 401 response interceptor and boot-time JWT expiry check (Closes #95)

### DIFF
--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -9,9 +9,27 @@ const api = axios.create({
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem("token");
   if (token) {
-    config.headers.Authorization = `Bearer ${token}`;         
+    config.headers.Authorization = `Bearer ${token}`;
   }
   return config;
 });
+
+// Response interceptor — when the server rejects a request because the JWT has
+// expired or is otherwise invalid (401), clear the stale session and send the
+// user to the login page instead of letting the call fail silently while the UI
+// still shows them as logged in.
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      localStorage.clear();
+      // Avoid a redirect loop if the 401 came from the login page itself.
+      if (window.location.pathname !== "/login") {
+        window.location.href = "/login";
+      }
+    }
+    return Promise.reject(error);
+  }
+);
 
 export default api;

--- a/frontend/src/features/auth/authSlice.js
+++ b/frontend/src/features/auth/authSlice.js
@@ -2,7 +2,28 @@ import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import { toast } from "react-toastify";
 import { loginAPI, registerAPI } from "./authService";
 
-const user = JSON.parse(localStorage.getItem("user"));
+// Decode a JWT's `exp` claim (standard base64url JSON — no library needed) and
+// check it against the current time. Returns false for a missing, malformed, or
+// expired token so a stale 7-day-old session never re-hydrates as "logged in".
+const isTokenValid = (token) => {
+  if (!token) return false;
+  try {
+    const payload = JSON.parse(atob(token.split(".")[1]));
+    return payload.exp * 1000 > Date.now();
+  } catch {
+    return false;
+  }
+};
+
+const storedToken = localStorage.getItem("token");
+// If the stored token is invalid/expired, clear the session before the Redux
+// store initialises so the user never briefly appears logged in on boot.
+if (!isTokenValid(storedToken)) {
+  localStorage.clear();
+}
+const user = isTokenValid(storedToken)
+  ? JSON.parse(localStorage.getItem("user"))
+  : null;
 
 export const login = createAsyncThunk(
   "auth/login",


### PR DESCRIPTION
## Summary
Fixes both gaps described in #95. An expired JWT session no longer stays active — the frontend now detects expiry both reactively (on any 401 API response) and proactively (before the Redux store initialises on boot).

Closes #95

---

## Root cause confirmed

**`frontend/src/api/axios.js`** — has a request interceptor that attaches the token, but no response interceptor. When the backend returns 401 (expired/invalid token), nothing catches it. Every API call silently rejects while the UI still shows the user as logged in.

**`frontend/src/features/auth/authSlice.js`** — hydrates `user` from `localStorage` on startup with no validity check. A user with a 7-day-old token reloads the app on day 8, appears logged in, and every subsequent API call immediately 401s.

Both gaps were verified against the actual files before writing any code.

---

## Changes — 2 files modified

**`frontend/src/api/axios.js`**
Added a response interceptor after the existing request interceptor. On any 401 response, it calls `localStorage.clear()` and redirects to `/login`. Includes a redirect-loop guard — won't redirect if the current path is already `/login` (prevents an infinite reload if a login request itself returns 401).

**`frontend/src/features/auth/authSlice.js`**
Added `isTokenValid(token)` before the initial state declaration. It decodes the JWT's `exp` claim using native `atob` (no new library), multiplies by 1000 to convert to milliseconds, and compares against `Date.now()`. If the stored token is missing, malformed, or expired, `localStorage.clear()` runs before the Redux store initialises — so the user never briefly appears logged in on boot. The `user` initial state is `null` for an invalid/expired token and the parsed user object for a valid one.

---

## Verification

**`isTokenValid` tested against 8 edge cases:**
- `null` → `false` ✓
- empty string → `false` ✓
- malformed (no dots) → `false` ✓
- malformed (2 parts) → `false` ✓
- expired (1 hour ago) → `false` ✓
- valid (1 hour from now) → `true` ✓
- valid (7 days) → `true` ✓
- token with no `exp` claim → `false` (NaN > x = false) ✓

**Backend confirmed:** `middlewares/authWebToken.js` returns 401 for missing, invalid, and expired tokens — interceptor catching 401 is the correct signal.

**Boot-time order confirmed:** `store.js` imports `authReducer` which causes `authSlice.js` to execute at module load, before `ReactDOM.render` in `main.jsx`. The `localStorage.clear()` runs before any component can read `user`.

**Login flow unaffected:** `login.fulfilled` stores a fresh token via `localStorage.setItem("token", action.payload.token)`. On next boot, this fresh valid token passes `isTokenValid` and `user` hydrates correctly.

**Cleanup consistent:** The interceptor uses `localStorage.clear()` — same as the existing `logout()` reducer.

---

## Checklist
- [x] Assigned before opening this PR
- [x] Both gaps from #95 fixed — 401 interceptor + boot-time expiry check
- [x] No new dependencies — uses native `atob` (browser global, Vite/React app)
- [x] Redirect-loop guard on the interceptor
- [x] `isTokenValid` handles null / malformed / expired / no-exp-claim inputs
- [x] Boot-time clear runs before Redux store initialises
- [x] Login flow verified — fresh token hydrates correctly on next boot
- [x] Backend 401 behavior verified against `middlewares/authWebToken.js`
- [x] Both files `node --check` + `esbuild` clean
- [x] 2 files modified · 0 new files · 0 new dependencies